### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Serialize/Tiny.pm
+++ b/lib/Serialize/Tiny.pm
@@ -1,4 +1,4 @@
-module Serialize::Tiny;
+unit module Serialize::Tiny;
 
 sub serialize(Mu:D \obj) is export {
   my \type = obj.WHAT;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.