### PR TITLE
Make things work with Rakudo 2015.12.

### DIFF
--- a/lib/Serialize/Tiny.pm
+++ b/lib/Serialize/Tiny.pm
@@ -2,6 +2,6 @@ unit module Serialize::Tiny;
 
 sub serialize(Mu:D \obj) is export {
   my \type = obj.WHAT;
-  my @attribute = type.^attributes.grep(*.has-accessor);
-  @attribute.map({.name.substr(2), .get_value(obj)}).hash
+  my @attribute = type.^attributes.grep(*.has_accessor);
+  @attribute.map({.name.substr(2) => .get_value(obj)}).hash
 }


### PR DESCRIPTION
Hi,

Thanks for writing this simple, yet quite useful module!

What do you think about the following two changes to make it work with the long-awaited Christmas release of Rakudo?
- the .has-accessor method has been renamed to .has_accessor
- the .hash method now expects a sequence of Pair objects, not plain List ones

Thanks again, and keep up the great work!

G'luck,
Peter