### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ class A {
 
 use Serialize::Tiny;
 say serialize(A.new(:5pub));
-#=> {:a(5)}<>
+#=> {pub => 5}
 ```


### PR DESCRIPTION
Guessing the :a is a pasto from the test file.  A newer Rakudo may also be serializing somewhat differently.