### PR TITLE
Fix test that assumed a specific output of .keys

### DIFF
--- a/t/01-test.t
+++ b/t/01-test.t
@@ -13,5 +13,5 @@ class A {
 my A $a .= new(:1a, :b('o rly'));
 my %h = serialize($a);
 
-is %h.keys, <a b>, 'It will filter out the keys without accessors';
+is %h.keys.sort, <a b>, 'It will filter out the keys without accessors';
 is %h<a>, 1, 'It extracted the value correctly';


### PR DESCRIPTION
With MoarVM changes, the order of .keys is not the same from run to run.
Correct the test so we sort the keys before checking them.